### PR TITLE
Update the urls to respect Django 1.10

### DIFF
--- a/rest_framework_swagger/urls.py
+++ b/rest_framework_swagger/urls.py
@@ -1,11 +1,9 @@
-from django.conf.urls import patterns
 from django.conf.urls import url
 from rest_framework_swagger.views import SwaggerResourcesView, SwaggerApiView, SwaggerUIView
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', SwaggerUIView.as_view(), name="django.swagger.base.view"),
     url(r'^api-docs/$', SwaggerResourcesView.as_view(), name="django.swagger.resources.view"),
     url(r'^api-docs/(?P<path>.*)/?$', SwaggerApiView.as_view(), name='django.swagger.api.view'),
-)
+]


### PR DESCRIPTION
**Why:** This will clear a warning that we currently have
